### PR TITLE
Add review-pr-multiharness-ponytail skill and Summary/Test plan PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Must match the diff. -->
+
+-
+
+## Test plan
+
+- [ ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .superpowers/
 .claude
 docs/superpowers
+graphify-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Full step-by-step logic for each workflow lives in `skills/*/SKILL.md` (shared h
 | `commands/create-pr.md` | Open PR against main, link Jira, notify Slack |
 | `commands/review-pr.md` | Analyze PR: correctness, naming, coverage + structured review |
 | `commands/review-pr-multiharness.md` | Analyze PR with risk-proportional multi-harness coverage and up to ten subagents |
+| `commands/review-pr-multiharness-ponytail.md` | Same as review-pr-multiharness, plus a required over-engineering deletion pass |
 | `commands/address-review.md` | Resolve review comments one-by-one, update docs |
 | `commands/verify-resolved.md` | Verify that your review comments on someone else's PR were correctly addressed |
 | `commands/merge-pr.md` | Merge PR, move ticket to In Staging, notify Slack |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to thebous-os
+
+Thanks for contributing. This repository follows
+[GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow).
+Every change lands on `main` through a pull request. Do not push to `main`
+directly.
+
+If you do not have write access, [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo),
+push to your fork, and open a PR into `TheBous/thebous-os`.
+
+Canonical workflow logic lives in `skills/*/SKILL.md`. Run those skills from
+your coding agent instead of re-implementing the steps by hand.
+
+## Development setup
+
+Requirements: Node.js 18+, Git, and an authenticated `gh` CLI (`gh auth login`).
+
+```bash
+git clone https://github.com/TheBous/thebous-os.git
+cd thebous-os
+npm test
+```
+
+The suite validates skill frontmatter, command adapters, provider portability,
+manifest version alignment and key workflow requirements.
+
+Keep credentials in
+`${THEBOUS_OS_DATA_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/thebous-os}/.env`.
+Never commit API tokens, app passwords or webhooks.
+
+## Workflow
+
+| Step | Skill | What to do |
+|---|---|---|
+| Start work | `thebous-os:new-branch` | Branch from `main`. From a Jira ticket: `feat/<key>-<slug>` |
+| Implement | `thebous-os:cook` | Code, tests and docs on that branch |
+| Open a PR | `thebous-os:create-pr` | PR against `main`. Title `[KEY] <ticket title>` when a Jira ticket exists |
+| Explain a PR | `thebous-os:explain-change` | Visual walkthrough of the PR, diff or implementation |
+| Review | `thebous-os:review-pr` | Structured review with inline comments |
+| Address review | `thebous-os:address-review` | Resolve review comments one by one |
+| Merge | `thebous-os:merge-pr` | Squash into `main` (default), then Jira → In Staging |
+| Release | `thebous-os:tag` | Create the tag, Jira → Done, notify Slack |
+
+## Opening a pull request
+
+1. Branch from an up-to-date `main`. Keep the branch short-lived and focused on
+   one change.
+2. Run `npm test` locally. Do not open a PR that fails the suite.
+3. Push the branch and open a PR against `main` (`thebous-os:create-pr`).
+4. Fill in a real title and description. When a Jira ticket exists, the title
+   is `[KEY] <ticket title>` and the body must match the actual diff — no
+   placeholder sections.
+5. Request review. Use `thebous-os:explain-change` if reviewers need a
+   walkthrough of the PR or diff.
+
+## Review and merge
+
+- Reviewers use `thebous-os:review-pr`. Authors resolve comments with
+  `thebous-os:address-review`.
+- CI must pass. Do not skip CI. Do not force-push to `main`.
+- Prefer **squash merge** so `main` stays linear. Use a merge commit or rebase
+  only if you ask for it (`thebous-os:merge-pr` defaults to squash).
+- After a merge to `main`, `.github/workflows/bump-version.yml` bumps package
+  and plugin manifests automatically. Do not bump versions in the PR.
+
+## Architecture constraints
+
+- `skills/<name>/SKILL.md` is the only place for workflow logic.
+- `commands/<name>.md` is a thin adapter. It must not duplicate that logic.
+- Provider manifests (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`,
+  `.opencode/`) only expose the canonical skills.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Never commit API tokens, app passwords or webhooks.
 | Implement | `thebous-os:cook` | Code, tests and docs on that branch |
 | Open a PR | `thebous-os:create-pr` | PR against `main`. Title `[KEY] <ticket title>` when a Jira ticket exists |
 | Explain a PR | `thebous-os:explain-change` | Visual walkthrough of the PR, diff or implementation |
-| Review | `thebous-os:review-pr` | Structured review with inline comments |
+| Review | `thebous-os:review-pr` | Default structured review. Variants: `review-pr-multiharness`, `review-pr-multiharness-ponytail` |
 | Address review | `thebous-os:address-review` | Resolve review comments one by one |
 | Merge | `thebous-os:merge-pr` | Squash into `main` (default), then Jira → In Staging |
 | Release | `thebous-os:tag` | Create the tag, Jira → Done, notify Slack |
@@ -56,7 +56,9 @@ Never commit API tokens, app passwords or webhooks.
 
 ## Review and merge
 
-- Reviewers use `thebous-os:review-pr`. Authors resolve comments with
+- Reviewers use `thebous-os:review-pr` by default. For specialist coverage
+  use `thebous-os:review-pr-multiharness`; add a deletion pass with
+  `thebous-os:review-pr-multiharness-ponytail`. Authors resolve comments with
   `thebous-os:address-review`.
 - CI must pass. Do not skip CI. Do not force-push to `main`.
 - Prefer **squash merge** so `main` stays linear. Use a merge commit or rebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ Never commit API tokens, app passwords or webhooks.
    one change.
 2. Run `npm test` locally. Do not open a PR that fails the suite.
 3. Push the branch and open a PR against `main` (`thebous-os:create-pr`).
-4. Fill in a real title and description. When a Jira ticket exists, the title
-   is `[KEY] <ticket title>` and the body must match the actual diff — no
-   placeholder sections.
+   GitHub pre-fills the body from [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+4. Fill in a real title and description (replace every template placeholder).
+   When a Jira ticket exists, the title is `[KEY] <ticket title>`. The body
+   uses GitHub's Summary / Test plan format and must match the actual diff.
 5. Request review. Use `thebous-os:explain-change` if reviewers need a
    walkthrough of the PR or diff.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,9 @@ Never commit API tokens, app passwords or webhooks.
 ## Review and merge
 
 - Reviewers use `thebous-os:review-pr` by default. For specialist coverage
-  use `thebous-os:review-pr-multiharness`; add a deletion pass with
-  `thebous-os:review-pr-multiharness-ponytail`. Authors resolve comments with
+  use `thebous-os:review-pr-multiharness`. When a deletion pass is required,
+  use `thebous-os:review-pr-multiharness-ponytail` instead — it already runs
+  the parent workflow. Do not run both. Authors resolve comments with
   `thebous-os:address-review`.
 - CI must pass. Do not skip CI. Do not force-push to `main`.
 - Prefer **squash merge** so `main` stays linear. Use a merge commit or rebase

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ commit API tokens, app passwords or webhooks.
 | Show the current situation | `thebous-os:current-status` |
 | Open a pull request | `thebous-os:create-pr` |
 | Review a pull request | `thebous-os:review-pr` |
+| Review a PR (multiharness) | `thebous-os:review-pr-multiharness` |
 | Review a PR (multiharness + ponytail) | `thebous-os:review-pr-multiharness-ponytail` |
 | Merge a pull request | `thebous-os:merge-pr` |
 | Explain a change visually | `thebous-os:explain-change` |

--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ manifest version alignment and key workflow requirements.
 Version manifests are bumped automatically by
 `.github/workflows/bump-version.yml` after pushes to `main`.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for GitHub Flow, pull requests, review
+and merge. Do not push to `main` directly.
+
 ## Security and privacy
 
 The package can read project activity, Jira data, meeting notes and communication
@@ -266,6 +271,7 @@ hooks or external connectors before enabling them.
 
 ## Documentation
 
+- [Contributing](CONTRIBUTING.md)
 - [Claude Code plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
 - [Codex plugins](https://developers.openai.com/codex/plugins/)
 - [OpenCode plugins](https://opencode.ai/docs/plugins/)

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ commit API tokens, app passwords or webhooks.
 | Show the current situation | `thebous-os:current-status` |
 | Open a pull request | `thebous-os:create-pr` |
 | Review a pull request | `thebous-os:review-pr` |
+| Review a PR (multiharness + ponytail) | `thebous-os:review-pr-multiharness-ponytail` |
 | Merge a pull request | `thebous-os:merge-pr` |
 | Explain a change visually | `thebous-os:explain-change` |
 | Run the morning briefing | `thebous-os:morning-briefing` |

--- a/commands/review-pr-multiharness-ponytail.md
+++ b/commands/review-pr-multiharness-ponytail.md
@@ -1,0 +1,5 @@
+---
+description: Review a GitHub PR with risk-proportional multi-harness coverage and a required over-engineering deletion pass
+---
+
+Use the canonical `skills/review-pr-multiharness-ponytail/SKILL.md` skill for this workflow. Load it and follow its instructions exactly.

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -75,46 +75,26 @@ Do not create the PR unless every item is `✅ Met` and the user confirms. If an
 
 ### 5. Auto-generate title and description
 
-**Title**: `[<KEY>] <Jira ticket title>`.
+**Title**: `[<KEY>] <Jira ticket title>`. If there is no Jira key, use a short title from the diff.
 
-**Description**: fill in the following template based on the diff analysis and Jira ticket details. Don't leave sections with generic placeholders — each section must reflect the actual changes found in the diff.
+**Description**: use GitHub's Summary / Test plan format. If the repository has
+`.github/PULL_REQUEST_TEMPLATE.md` or a file under `.github/PULL_REQUEST_TEMPLATE/`,
+fill that template. Otherwise fill the default below. If `CONTRIBUTING.md`
+exists, follow its PR title and body rules as well.
+
+Don't leave placeholder text — each section must reflect the actual diff.
 
 ```markdown
 ## Summary
-[1-3 sentences explaining what this PR does and why, based on the Jira title/description and the diff]
-
-## Changes
-- [Bulleted list of specific changes found in the diff]
-- [Group related changes together]
-- [Specify what was added, modified, or removed]
-
-## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Refactoring (no functional changes)
-
-## Testing
-- [ ] [Describe the testing performed, detected from test files in the diff]
-- [ ] [List any new tests added]
-- [ ] [Notes on any manual testing steps]
-
-## Breaking Changes
-[If applicable, describe breaking changes and migration steps; otherwise write "None"]
-
-## Related Issues
+- [1–3 bullets: what this PR does and why]
 Fixes <JIRA_BASE_URL>/browse/<KEY>
 
-## Screenshots
-[If applicable, add screenshots; otherwise remove this section]
-
-## Additional Context
-[Any other context useful for reviewers, or remove this section if not needed]
+## Test plan
+- [ ] [How this was verified: tests run, new tests, or manual steps]
 ```
 
-Automatically check the correct checkbox in "Type of Change" based on the analyzed diff.
+Omit the `Fixes` line when there is no Jira key. Put screenshots under Summary
+only if step 6 collected one.
 
 ### 6. Ask for a screenshot (only if the change is visual)
 
@@ -125,11 +105,11 @@ If it's screenshot-worthy, ask the user:
 📸 This looks like a UI change — got a screenshot of the result? (paste an image URL, or say no to skip)
 ```
 
-- If they give a URL, embed it in the `## Screenshots` section: `![screenshot](<URL>)`.
-- If they say no or have none, leave the `## Screenshots` section as `_No screenshot provided._`.
+- If they give a URL, add it under Summary: `![screenshot](<URL>)`.
+- If they say no or have none, skip the image and continue.
 - If they only have a local file path, note that `gh`/the API can't upload images — tell them to drag the file into the PR description on GitHub after it's created, then move on.
 
-If the change isn't screenshot-worthy, skip this step silently and remove the `## Screenshots` section from the template.
+If the change isn't screenshot-worthy, skip this step silently.
 
 ### 7. Create the PR
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -5,7 +5,9 @@ description: Use when the user asks to create or open a pull request, or to merg
 
 ## Goal
 
-Create a Pull Request for the current branch against `main`, after validating the Jira task and automatically generating the title and description from the Jira ticket and the branch diff.
+Create a Pull Request for the current branch against `main`. Generate the
+title and description from the branch diff, plus the Jira ticket when one
+exists.
 
 ## Routing
 
@@ -38,10 +40,11 @@ git push -u origin "$(git branch --show-current)"
 
 Follow `references/jira-task-context.md` with:
 - `<SOURCES>` = the current branch name
-- `<REQUIRED>` = `required`
+- `<REQUIRED>` = `optional`
 - `<DETAILS>` = `basic`
 
-The resolved `<KEY>`, `<TASK_SUMMARY>`, and `<TASK_DESCRIPTION>` are used in the PR title and description.
+If `<KEY>` is empty, continue with no Jira context. If it is set,
+`<TASK_SUMMARY>` and `<TASK_DESCRIPTION>` feed the PR title and body.
 
 ### 3. Analyze the diff against the base branch
 
@@ -60,7 +63,9 @@ Analyze the diff to identify:
 
 **Don't trust the diff hunk alone** for this — when it doesn't show the full function body, type definitions, or imports needed to judge the change, read the full file locally (it's already checked out on this branch, no need for the GitHub API).
 
-### 4. Validate the implementation against Jira (mandatory gate)
+### 4. Validate the implementation against Jira
+
+If `<KEY>` is empty, skip this step.
 
 Compare the full diff and the tests against `<TASK_REQUIREMENTS>` from `references/jira-task-context.md`.
 
@@ -83,6 +88,9 @@ fill that template. Otherwise fill the default below. If `CONTRIBUTING.md`
 exists, follow its PR title and body rules as well.
 
 Don't leave placeholder text — each section must reflect the actual diff.
+When filling a template, delete `<!-- -->` comments and replace dummy `-` /
+empty `- [ ]` with real bullets. Always pass `--body`. Add `Fixes
+<JIRA_BASE_URL>/browse/<KEY>` under Summary only when `<KEY>` is set.
 
 ```markdown
 ## Summary
@@ -113,6 +121,9 @@ If the change isn't screenshot-worthy, skip this step silently.
 
 ### 7. Create the PR
 
+If `<KEY>` is empty, show the generated title and body and wait for the user
+to confirm before creating.
+
 ```bash
 gh pr create \
   --base main \
@@ -135,7 +146,7 @@ curl -sf \
 
 ### 7a. Log the PR link to Obsidian (optional)
 
-If `OBSIDIAN_VAULT_PATH` is configured, follow `references/obsidian-log.md`:
+If `<KEY>` is empty, skip this step. If `OBSIDIAN_VAULT_PATH` is configured, follow `references/obsidian-log.md`:
 
 ```bash
 source "scripts/helpers.sh"
@@ -143,9 +154,11 @@ load_env
 obsidian_log_pr "${OBSIDIAN_VAULT_PATH:-}" "<KEY>" "<PR_URL>" "[[<KEY>]] — PR opened: <PR_URL>"
 ```
 
-### 8. Jira comment (always)
+### 8. Jira comment
 
-Always leave a comment on the Jira issue:
+If `<KEY>` is empty, skip steps 8 and 9.
+
+Leave a comment on the Jira issue:
 
 ```bash
 source "scripts/helpers.sh"
@@ -173,17 +186,26 @@ If the transition fails or `JIRA_IN_REVIEW_ID` is not configured, **continue any
 ```bash
 source "scripts/helpers.sh"
 load_env
+```
+
+If `<KEY>` is set:
+```bash
 slack_notify "🔍 PR opened: *<PR_TITLE>*\n🔗 <PR_URL>\n🎫 <$JIRA_BASE_URL/browse/<KEY>|<KEY>> → *In Review*"
 ```
 
-If Slack notification fails, **continue anyway** — the PR and Jira comment were already done.
+If `<KEY>` is empty:
+```bash
+slack_notify "🔍 PR opened: *<PR_TITLE>*\n🔗 <PR_URL>"
+```
+
+If Slack notification fails, **continue anyway** — the PR (and Jira comment, if any) were already done.
 
 ### 11. Confirmation
 
 Show the user:
 - PR created: `<PR_URL>`
-- Jira comment: left on `<KEY>`
+- Jira comment: left on `<KEY>` (or skipped, no key)
 - Ticket `<KEY>` → In Review (if transition succeeded; otherwise note it was skipped)
 - Slack: notified (or "notification failed, but PR and comment are done")
-- Obsidian: PR link recorded (or "skipped, no vault configured")
+- Obsidian: PR link recorded (or "skipped, no vault configured / no key")
 - → Suggest the next step: `/thebous-os:review-pr` to get it reviewed

--- a/skills/review-pr-multiharness-ponytail/SKILL.md
+++ b/skills/review-pr-multiharness-ponytail/SKILL.md
@@ -22,8 +22,12 @@ how it changes roster, report, and GitHub posting.
   `Coverage`.
 - Ceiling remains 10. If optional lenses would exceed the ceiling, drop the
   lowest-ranked optional lens. Never drop `correctness` or `ponytail`.
-- Before dispatch, load the ponytail prompt from
-  [`references/reviewer-prompts/ponytail.md`](references/reviewer-prompts/ponytail.md).
+- Before dispatch, load all three ponytail references and give them to the
+  ponytail subagent. The prompt is the output contract; the other two are
+  the judgment engine. Do not dispatch ponytail with the prompt alone.
+  - [`references/reviewer-prompts/ponytail.md`](references/reviewer-prompts/ponytail.md)
+  - [`references/ponytail-core.md`](references/ponytail-core.md)
+  - [`references/platform-native.md`](references/platform-native.md)
   Every other selected lens still loads its prompt from
   `skills/review-pr-multiharness/references/reviewer-prompts/`.
 - Stay report-only. Do not apply ponytail cuts unless the user explicitly

--- a/skills/review-pr-multiharness-ponytail/SKILL.md
+++ b/skills/review-pr-multiharness-ponytail/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: review-pr-multiharness-ponytail
+description: Use when reviewing, inspecting, or analyzing a GitHub pull request with specialist coverage plus an over-engineering deletion pass, or when the user invokes review-pr-multiharness-ponytail, asks for a ponytail PR review, or wants a merge decision and what to cut
+---
+
+# PR Review Multiharness + Ponytail
+
+A merge decision that can be defended in production, plus a deletion pass.
+The diff's best extra outcome is getting shorter.
+
+**REQUIRED SUB-SKILL:** Follow [`skills/review-pr-multiharness/SKILL.md`](../review-pr-multiharness/SKILL.md) in full.
+Do not copy that workflow here. This skill only adds the ponytail lens and
+how it changes roster, report, and GitHub posting.
+
+## Overrides
+
+- Always run `correctness` and `ponytail`. They are distinct lenses: never
+  coalesce `ponytail` into `maintainability`.
+- `ponytail` occupies one subagent slot. Capability tier: `fast`.
+- Minimum roster size is 2. If the parent danger table would dispatch 1,
+  dispatch 2 (`correctness` + `ponytail`) and record the override in
+  `Coverage`.
+- Ceiling remains 10. If optional lenses would exceed the ceiling, drop the
+  lowest-ranked optional lens. Never drop `correctness` or `ponytail`.
+- Before dispatch, load the ponytail prompt from
+  [`references/reviewer-prompts/ponytail.md`](references/reviewer-prompts/ponytail.md).
+  Every other selected lens still loads its prompt from
+  `skills/review-pr-multiharness/references/reviewer-prompts/`.
+- Stay report-only. Do not apply ponytail cuts unless the user explicitly
+  asks to apply them.
+
+## Ponytail findings
+
+Scope: over-engineering and complexity only. Correctness, security, and
+performance stay on their own lenses.
+
+One line per finding: `file:L<line>: <tag> <what>. <replacement>.`
+
+Tags: `delete:` (dead/speculative; replacement is nothing), `stdlib:` (name
+the stdlib function), `native:` (name the platform feature), `yagni:`
+(abstraction with one implementation), `shrink:` (same logic, fewer lines).
+
+Do not flag the single smoke test or `assert`-based self-check that ponytail
+requires. If there is nothing to cut, write `Lean already. Ship.` and skip
+the list.
+
+End the section with `net: -<N> lines possible.`
+
+## Report
+
+After the parent report contract, add:
+
+```text
+## Ponytail
+<one line per finding, or Lean already. Ship.>
+net: -<N> lines possible.
+```
+
+Ponytail findings are non-blocking (`SUGGESTION`). They do not change the
+verdict by themselves. If a cut also is a P0–P2 defect, the other lens owns
+severity; do not duplicate it in Actionable Findings.
+
+When GitHub posting is authorized, omit the Ponytail list from GitHub
+(treat it like discretionary P3). Keep it in the local report.
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "Maintainability already covers this" | Maintainability judges structure; ponytail only lists deletions in one-line form. Run both. |
+| "Score is 1, no room" | Override to 2. Correctness and ponytail are both required. |
+| "The PR is already small" | Small diffs still reinvent stdlib. Run the pass. |
+| "Nothing to cut, skip the section" | Write `Lean already. Ship.` so coverage is visible. |

--- a/skills/review-pr-multiharness-ponytail/SKILL.md
+++ b/skills/review-pr-multiharness-ponytail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr-multiharness-ponytail
-description: Use when reviewing, inspecting, or analyzing a GitHub pull request with specialist coverage plus an over-engineering deletion pass, or when the user invokes review-pr-multiharness-ponytail, asks for a ponytail PR review, or wants a merge decision and what to cut
+description: Use when the user invokes review-pr-multiharness-ponytail, asks for a ponytail PR review, or wants a merge decision plus what to cut. Same specialist coverage as review-pr-multiharness with a required over-engineering deletion pass.
 ---
 
 # PR Review Multiharness + Ponytail
@@ -10,21 +10,25 @@ The diff's best extra outcome is getting shorter.
 
 **REQUIRED SUB-SKILL:** Follow [`skills/review-pr-multiharness/SKILL.md`](../review-pr-multiharness/SKILL.md) in full.
 Do not copy that workflow here. This skill only adds the ponytail lens and
-how it changes roster, report, and GitHub posting.
+how it changes roster, report, and GitHub posting. Parent steps still run:
+explain-change, danger score, JSON dispatch contract, report-only GitHub rules.
 
 ## Overrides
 
 - Always run `correctness` and `ponytail`. They are distinct lenses: never
   coalesce `ponytail` into `maintainability`.
-- `ponytail` occupies one subagent slot. Capability tier: `fast`.
+- `ponytail` occupies one of the parent's per-score slots. Capability tier:
+  `fast`. Use parent count N. Never exceed N except the 1→2 override below.
+  Hard cap remains 10.
 - Minimum roster size is 2. If the parent danger table would dispatch 1,
   dispatch 2 (`correctness` + `ponytail`) and record the override in
   `Coverage`.
-- Ceiling remains 10. If optional lenses would exceed the ceiling, drop the
-  lowest-ranked optional lens. Never drop `correctness` or `ponytail`.
-- Before dispatch, load all three ponytail references and give them to the
-  ponytail subagent. The prompt is the output contract; the other two are
-  the judgment engine. Do not dispatch ponytail with the prompt alone.
+- If required lenses plus optionals would exceed N (or 10), drop the
+  lowest-ranked optional. Never drop `correctness` or `ponytail`.
+- Before dispatch, inline all three ponytail files into that subagent's
+  prompt (parent's one-prompt rule does not apply to this lens). The prompt
+  is the output contract; the other two are the judgment engine. Do not
+  dispatch ponytail with the prompt alone.
   - [`references/reviewer-prompts/ponytail.md`](references/reviewer-prompts/ponytail.md)
   - [`references/ponytail-core.md`](references/ponytail-core.md)
   - [`references/platform-native.md`](references/platform-native.md)

--- a/skills/review-pr-multiharness-ponytail/references/platform-native.md
+++ b/skills/review-pr-multiharness-ponytail/references/platform-native.md
@@ -1,0 +1,213 @@
+<!-- Source: DietrichGebert/ponytail docs/platform-native.md, MIT License. Copyright (c) 2026 DietrichGebert -->
+
+# Platform-Native Solutions
+
+The lazy senior dev's first question is always: *does the platform already do this?*
+
+This document answers that question for the most common cases. Before reaching for a package, scan here. The platform ships with your app for free, doesn't break on updates, and was written by people whose job is exactly that problem.
+
+---
+
+## HTML Elements
+
+Things the browser already has as a form control.
+
+| You think you need | What the platform has |
+|---|---|
+| Date picker library | `<input type="date">` |
+| Time picker library | `<input type="time">` |
+| Color picker library | `<input type="color">` |
+| Range slider library | `<input type="range">` |
+| Progress bar component | `<progress value="70" max="100">` |
+| Meter/gauge component | `<meter value="0.7">` |
+| Modal/dialog library | `<dialog>` + `dialog.showModal()` |
+| Accordion/FAQ component | `<details><summary>Title</summary>…</details>` |
+| Tooltip library | `title` attribute + CSS `::before`/`::after` |
+| Searchable dropdown | `<input list="id"> <datalist id="id">` |
+| Auto-growing textarea | `field-sizing: content` (CSS) |
+| Sticky header | `position: sticky; top: 0` (CSS) |
+
+---
+
+## CSS Capabilities
+
+Things developers reach for JavaScript to do.
+
+| You think you need JS for | What CSS has |
+|---|---|
+| Responsive font size | `font-size: clamp(1rem, 2.5vw, 2rem)` |
+| Fluid spacing | `padding: clamp(1rem, 5vw, 3rem)` |
+| Dark mode | `@media (prefers-color-scheme: dark)` |
+| Reduced motion | `@media (prefers-reduced-motion: reduce)` |
+| Responsive layout without breakpoints | `grid-template-columns: repeat(auto-fill, minmax(250px, 1fr))` |
+| Component-level responsive design | `@container` queries |
+| Global design tokens / theming | CSS custom properties (`--color-primary: #7c3aed`) |
+| Smooth scroll | `scroll-behavior: smooth` |
+| Scroll-snap carousel | `scroll-snap-type: x mandatory` + `scroll-snap-align: start` |
+| Aspect ratio enforcement | `aspect-ratio: 16 / 9` |
+| Truncate text with ellipsis | `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` |
+| Multi-line text clamp | `-webkit-line-clamp: 3` |
+| CSS cascade layers (style isolation) | `@layer base, components, utilities` |
+| Nested CSS selectors | Native CSS nesting (no preprocessor needed) |
+| `has()` parent selector | `:has(input:checked)` |
+
+---
+
+## JavaScript / Browser APIs
+
+Libraries people install that the runtime already ships.
+
+| You think you need | What the platform has |
+|---|---|
+| `query-string` / `qs` | `new URLSearchParams(location.search)` |
+| `lodash.clonedeep` | `structuredClone(obj)` |
+| `lodash.groupby` | `Object.groupBy(arr, fn)` |
+| `lodash.debounce` | see debounce one-liner below |
+| `numeral` / `accounting` | `new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" })` |
+| `date-fns` format | `new Intl.DateTimeFormat("en-US", { dateStyle: "long" }).format(date)` |
+| `date-fns` relative time | `new Intl.RelativeTimeFormat("en", { numeric: "auto" }).format(-3, "day")` |
+| `plural` / `i18n` plurals | `new Intl.PluralRules("en-US").select(count)` |
+| `clipboard.js` | `navigator.clipboard.writeText(text)` |
+| `uuid` (v4) | `crypto.randomUUID()` |
+| Infinite scroll library | `new IntersectionObserver(cb).observe(sentinel)` |
+| Resize listener library | `new ResizeObserver(cb).observe(element)` |
+| DOM mutation watcher | `new MutationObserver(cb).observe(el, options)` |
+| `uuid-validate` | `/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)` |
+| `is-online` / `connectivity check` | `navigator.onLine` + `online`/`offline` events |
+| `sharesheet` library | `navigator.share({ title, text, url })` |
+| `store.js` / `localForage` (simple case) | `localStorage.setItem(key, JSON.stringify(val))` |
+| Abort fetch on timeout | `AbortSignal.timeout(5000)` passed to `fetch` |
+| Custom event bus | `new EventTarget()` / `dispatchEvent(new CustomEvent("x", { detail }))` |
+
+**Debounce one-liner** (no library):
+```js
+// ponytail: 3 lines beats a dependency
+let t;
+const debounce = (fn, ms) => (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+```
+
+---
+
+## Swift / SwiftUI
+
+UI components people reach for a library or a custom view for.
+
+| You think you need | What the platform has |
+|---|---|
+| Date/time picker library | `DatePicker` |
+| Color picker library | `ColorPicker` |
+| Search bar + filtering | `.searchable(text:)` |
+| Pull-to-refresh library | `.refreshable { }` |
+| Swipe-to-delete / row actions | `.swipeActions { }` |
+| Async image loading + cache | `AsyncImage` |
+| Charting library | Swift Charts (`import Charts`) |
+| Markdown rendering | `Text(...)` markdown / `AttributedString(markdown:)` |
+| Share sheet wrapper | `ShareLink` |
+| Loading spinner | `ProgressView()` |
+| Photo picker | `PhotosPicker` |
+| Map SDK (basic) | `Map` (MapKit for SwiftUI) |
+| Grid layout library | `Grid` / `LazyVGrid` |
+
+Frameworks and stdlib that wrappers wrap.
+
+| You think you need | What the platform has |
+|---|---|
+| JSON library (SwiftyJSON) | `Codable` + `JSONDecoder` / `JSONEncoder` |
+| HTTP client (Alamofire, simple use) | `URLSession` async/await; Alamofire earns it for complex retry/multipart at scale |
+| Date/number/currency formatting | `.formatted()` / `FormatStyle` |
+| Regex library | Swift regex literals + `Regex` |
+| Crypto library (CryptoSwift) | `CryptoKit` |
+| Keychain wrapper | Security `SecItem`; a few lines, not a dependency |
+| Persistence / ORM | `SwiftData`, or `@AppStorage` for small key-values |
+| Logging library | `Logger` (`os.log`) |
+| UUID / Base64 helpers | `UUID()`, `Data(...).base64EncodedString()` |
+| Image downsampling | ImageIO `CGImageSourceCreateThumbnailAtIndex` |
+| Combine wrappers for async | async/await + `AsyncSequence` |
+
+---
+
+## Node.js Standard Library
+
+Packages that wrap Node built-ins.
+
+| You think you need | What Node has |
+|---|---|
+| `mkdirp` | `fs.mkdirSync(path, { recursive: true })` |
+| `rimraf` | `fs.rmSync(path, { recursive: true, force: true })` |
+| `make-dir` | `fs.mkdirSync(path, { recursive: true })` |
+| `slash` (win paths) | `path.posix` or `path.normalize()` |
+| `uuid` (v4) | `crypto.randomUUID()` |
+| `ms` (parse duration strings) | keep `ms`, it's genuinely useful and tiny |
+| `is-stream` | `val instanceof stream.Readable` |
+| `object-assign` | `Object.assign()` / spread |
+| `array-uniq` | `[...new Set(arr)]` |
+| `array-flatten` | `arr.flat(Infinity)` |
+| `flat` | `arr.flat(depth)` |
+| `path-exists` | `fs.existsSync(path)` |
+| `load-json-file` | `JSON.parse(fs.readFileSync(path, "utf8"))` |
+| `write-json-file` | `fs.writeFileSync(path, JSON.stringify(obj, null, 2))` |
+| `pkg-dir` | `path.resolve(__dirname, "..")` / `import.meta.dirname` |
+
+---
+
+## Python Standard Library
+
+Packages that wrap what Python already ships.
+
+| You think you need | What Python has |
+|---|---|
+| `python-dateutil` (basic parsing) | `datetime.fromisoformat()` (Python 3.7+) |
+| `pytz` | `zoneinfo.ZoneInfo("America/New_York")` (Python 3.9+) |
+| `attrs` (simple data classes) | `@dataclass` |
+| `six` | drop it, Python 2 is gone |
+| `pathlib2` | `pathlib.Path` (built-in since Python 3.4) |
+| `enum34` | `enum.Enum` (built-in since Python 3.4) |
+| `typing_extensions` (common types) | `from __future__ import annotations` + built-in generics |
+| `simplejson` (basic use) | `json` (stdlib) |
+| `requests` (simple GET) | `urllib.request.urlopen(url)`, `requests` for anything real |
+| `click` (single command) | `argparse` (stdlib) |
+| `mergedeep` | `dict \| other_dict` (Python 3.9+) |
+| `more-itertools` (basic) | `itertools` (stdlib): `chain`, `islice`, `groupby`, `product` |
+| `toolz` (basic) | `functools`: `lru_cache`, `partial`, `reduce` |
+| `tabulate` (dev/debug only) | `pprint.pprint()` for quick inspection |
+
+---
+
+## Database
+
+Things the application layer implements that the database already does.
+
+| You think you need app code for | What the database has |
+|---|---|
+| Pagination offset/limit | `LIMIT 20 OFFSET 40` |
+| Running totals | `SUM(...) OVER (ORDER BY date)` (window function) |
+| Rank within group | `RANK() OVER (PARTITION BY category ORDER BY score DESC)` |
+| Pivot / cross-tab | `FILTER (WHERE ...)` + conditional aggregation |
+| Deduplication | `SELECT DISTINCT` / `ON CONFLICT DO NOTHING` |
+| Soft-delete filtering | Generated column + partial index |
+| Tree traversal | Recursive CTE (`WITH RECURSIVE`) |
+| Full-text search (basic) | `tsvector` / `MATCH AGAINST` / `FTS5` |
+| JSON storage + query | `jsonb` (Postgres) / `JSON_EXTRACT` (SQLite/MySQL) |
+| UUID generation | `gen_random_uuid()` (Postgres) / `UUID()` (MySQL) |
+| Timestamps on insert/update | `DEFAULT now()` + trigger or `ON UPDATE CURRENT_TIMESTAMP` |
+| Enforce uniqueness | `UNIQUE` constraint, not application-level checks |
+| Enforce referential integrity | `FOREIGN KEY`, not application-level checks |
+| Enforce value ranges | `CHECK (price > 0)`, not application-level validation |
+
+---
+
+## The Pattern
+
+Across every layer, the pattern is the same:
+
+```
+Platform team spends years solving the problem.
+Package author wraps it.
+You install the wrapper.
+The wrapper goes unmaintained.
+You debug the wrapper.
+```
+
+Skip the wrapper. The platform ships with your app for free.
+
+When the native solution is genuinely insufficient (old browser support, edge cases it doesn't handle, ergonomics that matter at scale), the library earns its place. Install it then, not before.

--- a/skills/review-pr-multiharness-ponytail/references/platform-native.md
+++ b/skills/review-pr-multiharness-ponytail/references/platform-native.md
@@ -59,7 +59,7 @@ Libraries people install that the runtime already ships.
 
 | You think you need | What the platform has |
 |---|---|
-| `query-string` / `qs` | `new URLSearchParams(location.search)` |
+| `query-string` / `qs` | `new URLSearchParams(location.search)` (flat queries; keep `qs` for nested/arrays) |
 | `lodash.clonedeep` | `structuredClone(obj)` |
 | `lodash.groupby` | `Object.groupBy(arr, fn)` |
 | `lodash.debounce` | see debounce one-liner below |
@@ -72,7 +72,7 @@ Libraries people install that the runtime already ships.
 | Infinite scroll library | `new IntersectionObserver(cb).observe(sentinel)` |
 | Resize listener library | `new ResizeObserver(cb).observe(element)` |
 | DOM mutation watcher | `new MutationObserver(cb).observe(el, options)` |
-| `uuid-validate` | `/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)` |
+| `uuid-validate` | `/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)` (UUID v4 only; keep the lib for v1–v5) |
 | `is-online` / `connectivity check` | `navigator.onLine` + `online`/`offline` events |
 | `sharesheet` library | `navigator.share({ title, text, url })` |
 | `store.js` / `localForage` (simple case) | `localStorage.setItem(key, JSON.stringify(val))` |
@@ -81,9 +81,8 @@ Libraries people install that the runtime already ships.
 
 **Debounce one-liner** (no library):
 ```js
-// ponytail: 3 lines beats a dependency
-let t;
-const debounce = (fn, ms) => (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+// ponytail: one timer per debounce(), per-key timers if one function serves many keys
+const debounce = (fn, ms) => { let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); }; };
 ```
 
 ---
@@ -135,7 +134,7 @@ Packages that wrap Node built-ins.
 | `mkdirp` | `fs.mkdirSync(path, { recursive: true })` |
 | `rimraf` | `fs.rmSync(path, { recursive: true, force: true })` |
 | `make-dir` | `fs.mkdirSync(path, { recursive: true })` |
-| `slash` (win paths) | `path.posix` or `path.normalize()` |
+| `slash` (win paths) | `s.replaceAll("\\", "/")` (`path.normalize` does not convert `\\`) |
 | `uuid` (v4) | `crypto.randomUUID()` |
 | `ms` (parse duration strings) | keep `ms`, it's genuinely useful and tiny |
 | `is-stream` | `val instanceof stream.Readable` |
@@ -146,7 +145,7 @@ Packages that wrap Node built-ins.
 | `path-exists` | `fs.existsSync(path)` |
 | `load-json-file` | `JSON.parse(fs.readFileSync(path, "utf8"))` |
 | `write-json-file` | `fs.writeFileSync(path, JSON.stringify(obj, null, 2))` |
-| `pkg-dir` | `path.resolve(__dirname, "..")` / `import.meta.dirname` |
+| `pkg-dir` | walk parents until `package.json` (`path.dirname` loop); `__dirname/..` is not discovery |
 
 ---
 
@@ -166,7 +165,7 @@ Packages that wrap what Python already ships.
 | `simplejson` (basic use) | `json` (stdlib) |
 | `requests` (simple GET) | `urllib.request.urlopen(url)`, `requests` for anything real |
 | `click` (single command) | `argparse` (stdlib) |
-| `mergedeep` | `dict \| other_dict` (Python 3.9+) |
+| `mergedeep` | `dict \| other_dict` (Python 3.9+, shallow right-biased; keep `mergedeep` for nested) |
 | `more-itertools` (basic) | `itertools` (stdlib): `chain`, `islice`, `groupby`, `product` |
 | `toolz` (basic) | `functools`: `lru_cache`, `partial`, `reduce` |
 | `tabulate` (dev/debug only) | `pprint.pprint()` for quick inspection |
@@ -200,7 +199,7 @@ Things the application layer implements that the database already does.
 
 Across every layer, the pattern is the same:
 
-```
+```text
 Platform team spends years solving the problem.
 Package author wraps it.
 You install the wrapper.

--- a/skills/review-pr-multiharness-ponytail/references/ponytail-core.md
+++ b/skills/review-pr-multiharness-ponytail/references/ponytail-core.md
@@ -75,7 +75,7 @@ thing, dead flags and config, hand-rolled stdlib.
 
 ## `ponytail:` debt in this diff (from ponytail-debt)
 
-Grep the changed files for `(#|//) ?ponytail:`. Each hit is a deliberate
+Grep the changed files for `(#|//|/\*|<!--) ?ponytail:`. Each hit is a deliberate
 shortcut. Report it as its own line if the comment names no ceiling or no
 upgrade trigger (`no-trigger` — those rot). Do not treat a well-formed
 `ponytail:` comment as a finding to delete; it is the allowed exception.

--- a/skills/review-pr-multiharness-ponytail/references/ponytail-core.md
+++ b/skills/review-pr-multiharness-ponytail/references/ponytail-core.md
@@ -1,0 +1,83 @@
+<!-- Source: DietrichGebert/ponytail (skills/ponytail, ponytail-audit, ponytail-debt), MIT License. Copyright (c) 2026 DietrichGebert -->
+
+# Ponytail judgment (review)
+
+This is the judgment engine behind `ponytail-review`. The one-line tags are
+the output format; this file is how to decide. Climb the ladder against every
+changed hunk after tracing the real flow. Do not apply cuts.
+
+Lazy means efficient, not careless. The best code is the code never written.
+
+## The ladder
+
+Stop at the first rung that holds. The ladder runs *after* you understand the
+problem, not instead of it: read the changed files, trace the flow end to end,
+then climb.
+
+1. **Does this need to exist at all?** Speculative need, unused flexibility,
+   feature flags nobody sets → `delete:`.
+2. **Already in this codebase?** A helper, util, type, or pattern a few files
+   over → `delete:` the reimplementation, name the existing one.
+3. **Stdlib does it?** Hand-rolled loop, parser, or util the language ships →
+   `stdlib:`, name the function.
+4. **Native platform feature covers it?** Check
+   [`platform-native.md`](platform-native.md) before flagging a new widget,
+   date lib, or CSS-in-JS → `native:`, name the feature.
+5. **Already-installed dependency solves it?** New package for what a few
+   lines or an existing dep already does → `delete:` the new dep.
+6. **Can it be one line?** Same logic, fewer lines → `shrink:`, show the
+   shorter form.
+7. **Only then:** leave it. Not every addition is bloat.
+
+Two rungs work → take the higher one. The first lazy replacement that
+preserves behavior is the right one — once you actually know what the hunk
+touches.
+
+**Bug-fix hunks:** a report names a symptom. If the PR guards one caller of a
+shared function, flag the sibling callers still broken as `yagni:` of a
+local patch: the lazy fix is one guard at the shared source.
+
+## Rules
+
+- No unrequested abstractions: interface with one implementation, factory
+  for one product, config for a value that never changes → `yagni:`.
+- No boilerplate, no scaffolding "for later".
+- Deletion over addition. Boring over clever.
+- Fewest files possible. Shortest working diff wins — but only once you
+  understand the problem. The smallest change in the wrong place is a
+  second bug, not a win: do not flag a correct root-cause fix as `shrink:`
+  just because a wrong one-liner is shorter.
+- Two stdlib options, same size? The edge-case-correct one is not bloat.
+- Deliberate shortcuts that cut a real corner must be marked
+  `ponytail: <ceiling>, <upgrade path>`.
+
+## When NOT to flag
+
+Never flag as over-engineering:
+
+- input validation at trust boundaries
+- error handling that prevents data loss
+- security measures
+- accessibility basics
+- hardware calibration knobs (clocks drift, sensors read off)
+- anything the PR description or ticket explicitly requested
+- the single smoke test or `assert`-based self-check that ponytail requires
+  for non-trivial logic (a branch, loop, parser, money/security path)
+
+If the extra complexity is itself a correctness, security, or performance
+defect, do not report it here.
+
+## Hunt (from ponytail-audit, scoped to the diff)
+
+Deps the stdlib or platform already ships, single-implementation interfaces,
+factories with one product, wrappers that only delegate, files exporting one
+thing, dead flags and config, hand-rolled stdlib.
+
+## `ponytail:` debt in this diff (from ponytail-debt)
+
+Grep the changed files for `(#|//) ?ponytail:`. Each hit is a deliberate
+shortcut. Report it as its own line if the comment names no ceiling or no
+upgrade trigger (`no-trigger` — those rot). Do not treat a well-formed
+`ponytail:` comment as a finding to delete; it is the allowed exception.
+A new shortcut without the comment is a `yagni:` or `shrink:` miss: the
+ceiling is unmarked.

--- a/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
+++ b/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
@@ -32,21 +32,22 @@ Climb the ladder against every changed hunk after tracing the real flow.
   it here — that belongs to another lens.
 - Do not flag the single smoke test or `assert`-based self-check that
   ponytail requires as the minimum check.
-- If there is nothing to cut, return no findings and set the summary to
-  `Lean already. Ship.`
-- End your notes with `net: -<N> lines possible.` (`net: -0` when lean).
+- If there is nothing to cut, return `"findings": []`. The orchestrator
+  writes `Lean already. Ship.`
+- Put `net: -<N> lines possible.` (`net: -0` when lean) in
+  `result.residual_risks[0]`. Keep ranges in evidence, not in `title`.
 
 ## Format examples
 
 ❌ "This EmailValidator class might be more complex than necessary, have you
 considered whether all these validation rules are needed at this stage?"
 
-✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+✅ `email.ts:L12: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
 
-✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+✅ `dates.js:L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
 
 ✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
 
-✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+✅ `http.py:L52: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
 
-✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+✅ `build.py:L30: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`

--- a/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
+++ b/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
@@ -1,0 +1,26 @@
+# Ponytail reviewer
+
+Review the diff for unnecessary complexity only. The best outcome is getting
+shorter. One line per finding: location, what to cut, what replaces it.
+Correctness, security, and performance are explicitly out of scope; leave
+those to their dedicated lenses. Do not apply the cuts.
+
+## Review rules
+
+- Hunt reinvented standard library, unneeded dependencies, speculative
+  abstractions, unused flexibility, and same-logic-fewer-lines rewrites.
+- `title` MUST be `file:L<line>: <tag> <what>. <replacement>.`
+- `category` MUST be one of: `delete`, `stdlib`, `native`, `yagni`, `shrink`.
+- Tags: `delete:` dead code, unused flexibility, speculative feature
+  (replacement: nothing); `stdlib:` hand-rolled thing the standard library
+  ships (name the function); `native:` dependency or code doing what the
+  platform already does (name the feature); `yagni:` abstraction with one
+  implementation, config nobody sets, layer with one caller; `shrink:` same
+  logic, fewer lines (show the shorter form).
+- Severity is `P3`. If the extra complexity is itself a defect, do not report
+  it here — that belongs to another lens.
+- Do not flag the single smoke test or `assert`-based self-check that
+  ponytail requires as the minimum check.
+- If there is nothing to cut, return no findings and set the summary to
+  `Lean already. Ship.`
+- End your notes with `net: -<N> lines possible.` (`net: -0` when lean).

--- a/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
+++ b/skills/review-pr-multiharness-ponytail/references/reviewer-prompts/ponytail.md
@@ -5,10 +5,21 @@ shorter. One line per finding: location, what to cut, what replaces it.
 Correctness, security, and performance are explicitly out of scope; leave
 those to their dedicated lenses. Do not apply the cuts.
 
+Before reviewing, read in full:
+
+- [`../ponytail-core.md`](../ponytail-core.md) — ladder, rules, when not to
+  flag, hunt list, `ponytail:` debt
+- [`../platform-native.md`](../platform-native.md) — catalog for `native:`
+  and `stdlib:` replacements. A `native:` or `stdlib:` finding must name
+  a concrete feature from that catalog or from the language/runtime docs.
+
+Climb the ladder against every changed hunk after tracing the real flow.
+
 ## Review rules
 
 - Hunt reinvented standard library, unneeded dependencies, speculative
-  abstractions, unused flexibility, and same-logic-fewer-lines rewrites.
+  abstractions, unused flexibility, wrappers that only delegate, and
+  same-logic-fewer-lines rewrites.
 - `title` MUST be `file:L<line>: <tag> <what>. <replacement>.`
 - `category` MUST be one of: `delete`, `stdlib`, `native`, `yagni`, `shrink`.
 - Tags: `delete:` dead code, unused flexibility, speculative feature
@@ -24,3 +35,18 @@ those to their dedicated lenses. Do not apply the cuts.
 - If there is nothing to cut, return no findings and set the summary to
   `Lean already. Ship.`
 - End your notes with `net: -<N> lines possible.` (`net: -0` when lean).
+
+## Format examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`

--- a/skills/review-pr-multiharness/SKILL.md
+++ b/skills/review-pr-multiharness/SKILL.md
@@ -88,12 +88,14 @@ applicable standards, generated files, and any plan or acceptance criteria.
 
 Read the PR description before the diff. Expect GitHub's Summary / Test
 plan format (or the repository's `.github/PULL_REQUEST_TEMPLATE.md` /
-`CONTRIBUTING.md` if present): filled sections and no leftover placeholders.
+`CONTRIBUTING.md` if present): filled sections whose claims match the
+diff, with no leftover placeholders.
 When a Jira key is present in the branch, title, or body, expect
 `[KEY] <ticket title>`; otherwise a non-placeholder title is enough. A
-description that still contains template comments or an empty Summary / Test
-plan is incomplete intent; record it in `Coverage` and raise it as
-`IMPORTANT` when `CONTRIBUTING.md` forbids placeholders.
+description that still contains template comments, an empty Summary / Test
+plan, or claims that contradict the diff is incomplete intent; record it
+in `Coverage` and raise it as `IMPORTANT` when `CONTRIBUTING.md` forbids
+placeholders or requires the body to match the diff.
 
 Infer problem, solution, non-goals, tests, configuration, migrations,
 rollout, risks, and follow-ups from the description and the diff. If intent

--- a/skills/review-pr-multiharness/SKILL.md
+++ b/skills/review-pr-multiharness/SKILL.md
@@ -88,11 +88,12 @@ applicable standards, generated files, and any plan or acceptance criteria.
 
 Read the PR description before the diff. Expect GitHub's Summary / Test
 plan format (or the repository's `.github/PULL_REQUEST_TEMPLATE.md` /
-`CONTRIBUTING.md` if present): filled sections, no leftover placeholders, and
-the required title format. A description that still contains template comments
-or an empty Summary / Test plan is incomplete intent; record it in
-`Coverage` and raise it as `IMPORTANT` when `CONTRIBUTING.md` forbids
-placeholders.
+`CONTRIBUTING.md` if present): filled sections and no leftover placeholders.
+When a Jira key is present in the branch, title, or body, expect
+`[KEY] <ticket title>`; otherwise a non-placeholder title is enough. A
+description that still contains template comments or an empty Summary / Test
+plan is incomplete intent; record it in `Coverage` and raise it as
+`IMPORTANT` when `CONTRIBUTING.md` forbids placeholders.
 
 Infer problem, solution, non-goals, tests, configuration, migrations,
 rollout, risks, and follow-ups from the description and the diff. If intent

--- a/skills/review-pr-multiharness/SKILL.md
+++ b/skills/review-pr-multiharness/SKILL.md
@@ -86,10 +86,18 @@ mix a remote PR diff with unrelated workspace files. Capture base/head refs,
 changed and untracked paths, PR title/description/commits/prior comments,
 applicable standards, generated files, and any plan or acceptance criteria.
 
-Read the PR description before the diff. It should explain problem, solution,
-non-goals, tests, configuration, migrations, rollout, risks, and follow-ups.
-If intent is incomplete, infer it from available evidence and mark uncertainty;
-do not block on a question.
+Read the PR description before the diff. Expect GitHub's Summary / Test
+plan format (or the repository's `.github/PULL_REQUEST_TEMPLATE.md` /
+`CONTRIBUTING.md` if present): filled sections, no leftover placeholders, and
+the required title format. A description that still contains template comments
+or an empty Summary / Test plan is incomplete intent; record it in
+`Coverage` and raise it as `IMPORTANT` when `CONTRIBUTING.md` forbids
+placeholders.
+
+Infer problem, solution, non-goals, tests, configuration, migrations,
+rollout, risks, and follow-ups from the description and the diff. If intent
+is incomplete, mark uncertainty; do not block on a question unless the
+contributing rules make the missing section a merge requirement.
 
 ### 4. Classify danger before selecting reviewers
 

--- a/skills/review-pr-multiharness/references/reviewer-prompts/standards.md
+++ b/skills/review-pr-multiharness/references/reviewer-prompts/standards.md
@@ -9,7 +9,9 @@ the repository and do not report subjective style preferences.
 
 ## Review rules
 
-- Treat applicable repository instructions as the highest authority.
+- Treat applicable repository instructions as the highest authority,
+  including `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` when
+  present. Flag a PR description that leaves Summary / Test plan placeholders.
 - Check required structure, naming, frontmatter, references, portability, tool
   choice, generated-file handling, and documentation obligations.
 - Cite the exact local rule and changed location for every finding.

--- a/skills/review-pr-multiharness/references/reviewer-prompts/standards.md
+++ b/skills/review-pr-multiharness/references/reviewer-prompts/standards.md
@@ -11,7 +11,8 @@ the repository and do not report subjective style preferences.
 
 - Treat applicable repository instructions as the highest authority,
   including `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` when
-  present. Flag a PR description that leaves Summary / Test plan placeholders.
+  present. Flag a PR description that leaves Summary / Test plan placeholders,
+  or whose Summary / Test plan claims contradict the diff.
 - Check required structure, naming, frontmatter, references, portability, tool
   choice, generated-file handling, and documentation obligations.
 - Cite the exact local rule and changed location for every finding.

--- a/tests/skills-portability.test.cjs
+++ b/tests/skills-portability.test.cjs
@@ -239,6 +239,8 @@ test('core workflow skills declare their automatic trigger conditions', () => {
   assert.match(createPr, /PULL_REQUEST_TEMPLATE/);
   assert.match(createPr, /## Summary/);
   assert.match(createPr, /## Test plan/);
+  assert.match(createPr, /<REQUIRED>` = `optional/);
+  assert.doesNotMatch(createPr, /<REQUIRED>` = `required/);
 });
 
 test('this repository pre-fills PRs with GitHub Summary / Test plan', () => {
@@ -274,6 +276,8 @@ test('review-pr-multiharness-ponytail follows the parent workflow and always run
   assert.match(skill, /always run `correctness` and `ponytail`/i);
   assert.match(skill, /never[\s\S]*coalesce[\s\S]*maintainability/i);
   assert.match(skill, /Minimum roster size is 2/);
+  assert.match(skill, /occupies one of the parent/);
+  assert.match(skill, /1→2|1->2/);
   assert.match(skill, /Lean already\. Ship\./);
   assert.match(skill, /net: -<N> lines possible/);
   assert.match(skill, /delete:|stdlib:|native:|yagni:|shrink:/);

--- a/tests/skills-portability.test.cjs
+++ b/tests/skills-portability.test.cjs
@@ -280,10 +280,11 @@ test('review-pr-multiharness-ponytail follows the parent workflow and always run
   assert.match(skill, /1→2|1->2/);
   assert.match(skill, /Lean already\. Ship\./);
   assert.match(skill, /net: -<N> lines possible/);
-  assert.match(skill, /delete:|stdlib:|native:|yagni:|shrink:/);
+  for (const tag of ['delete:', 'stdlib:', 'native:', 'yagni:', 'shrink:']) {
+    assert.match(skill, new RegExp(tag));
+    assert.match(prompt, new RegExp(tag));
+  }
   assert.doesNotMatch(skill, /haiku|sonnet|gpt-\d|claude/i);
-
-  assert.match(prompt, /delete:|stdlib:|native:|yagni:|shrink:/);
   assert.match(prompt, /over-engineering|complexity only/i);
   assert.match(prompt, /out of scope/i);
   assert.match(prompt, /ponytail-core\.md/);

--- a/tests/skills-portability.test.cjs
+++ b/tests/skills-portability.test.cjs
@@ -282,4 +282,22 @@ test('review-pr-multiharness-ponytail follows the parent workflow and always run
   assert.match(prompt, /delete:|stdlib:|native:|yagni:|shrink:/);
   assert.match(prompt, /over-engineering|complexity only/i);
   assert.match(prompt, /out of scope/i);
+  assert.match(prompt, /ponytail-core\.md/);
+  assert.match(prompt, /platform-native\.md/);
+  assert.match(prompt, /EmailValidator|Intl\.DateTimeFormat|AbstractRepository/);
+
+  const core = fs.readFileSync(
+    path.join(skillsDir, 'review-pr-multiharness-ponytail', 'references', 'ponytail-core.md'),
+    'utf8',
+  );
+  const native = fs.readFileSync(
+    path.join(skillsDir, 'review-pr-multiharness-ponytail', 'references', 'platform-native.md'),
+    'utf8',
+  );
+  assert.match(skill, /ponytail-core\.md/);
+  assert.match(skill, /platform-native\.md/);
+  assert.match(core, /Does this need to exist at all/);
+  assert.match(core, /When NOT to flag/);
+  assert.match(core, /ponytail:/);
+  assert.match(native, /structuredClone|Intl\.DateTimeFormat|fs\.mkdirSync/);
 });

--- a/tests/skills-portability.test.cjs
+++ b/tests/skills-portability.test.cjs
@@ -236,6 +236,16 @@ test('core workflow skills declare their automatic trigger conditions', () => {
   const createPr = fs.readFileSync(path.join(skillsDir, 'create-pr', 'SKILL.md'), 'utf8');
   assert.match(createPr, /merge.*branch|existing pull request/i);
   assert.match(createPr, /skills\/merge-pr\/SKILL\.md/);
+  assert.match(createPr, /PULL_REQUEST_TEMPLATE/);
+  assert.match(createPr, /## Summary/);
+  assert.match(createPr, /## Test plan/);
+});
+
+test('this repository pre-fills PRs with GitHub Summary / Test plan', () => {
+  const template = fs.readFileSync(path.join(root, '.github', 'PULL_REQUEST_TEMPLATE.md'), 'utf8');
+  assert.match(template, /^## Summary$/m);
+  assert.match(template, /^## Test plan$/m);
+  assert.doesNotMatch(template, /Type of Change/);
 });
 
 test('review-pr runs a fast walkthrough subagent and saves its HTML in the ticket review folder', () => {
@@ -247,4 +257,29 @@ test('review-pr runs a fast walkthrough subagent and saves its HTML in the ticke
   assert.match(review, /Dev\/Review\/DC-<TASK_ID>/);
   assert.match(review, /index\.html/);
   assert.match(review, /self-contained/i);
+});
+
+test('review-pr-multiharness-ponytail follows the parent workflow and always runs ponytail', () => {
+  const skill = fs.readFileSync(
+    path.join(skillsDir, 'review-pr-multiharness-ponytail', 'SKILL.md'),
+    'utf8',
+  );
+  const prompt = fs.readFileSync(
+    path.join(skillsDir, 'review-pr-multiharness-ponytail', 'references', 'reviewer-prompts', 'ponytail.md'),
+    'utf8',
+  );
+
+  assert.match(skill, /skills\/review-pr-multiharness\/SKILL\.md/);
+  assert.doesNotMatch(skill, /danger_score = sum/);
+  assert.match(skill, /always run `correctness` and `ponytail`/i);
+  assert.match(skill, /never[\s\S]*coalesce[\s\S]*maintainability/i);
+  assert.match(skill, /Minimum roster size is 2/);
+  assert.match(skill, /Lean already\. Ship\./);
+  assert.match(skill, /net: -<N> lines possible/);
+  assert.match(skill, /delete:|stdlib:|native:|yagni:|shrink:/);
+  assert.doesNotMatch(skill, /haiku|sonnet|gpt-\d|claude/i);
+
+  assert.match(prompt, /delete:|stdlib:|native:|yagni:|shrink:/);
+  assert.match(prompt, /over-engineering|complexity only/i);
+  assert.doesNotMatch(prompt, /correctness bugs|report style|security holes/i);
 });

--- a/tests/skills-portability.test.cjs
+++ b/tests/skills-portability.test.cjs
@@ -281,5 +281,5 @@ test('review-pr-multiharness-ponytail follows the parent workflow and always run
 
   assert.match(prompt, /delete:|stdlib:|native:|yagni:|shrink:/);
   assert.match(prompt, /over-engineering|complexity only/i);
-  assert.doesNotMatch(prompt, /correctness bugs|report style|security holes/i);
+  assert.match(prompt, /out of scope/i);
 });


### PR DESCRIPTION
## Summary
- Add `review-pr-multiharness-ponytail`: parent multi-harness review plus a required over-engineering pass. Ponytail occupies one of the parent per-score slots (bump only 1→2; hard cap 10) and must be dispatched with the output prompt, `ponytail-core.md`, and `platform-native.md`.
- Align PR writing with GitHub's Summary / Test plan (`CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `create-pr`). Jira is optional: no key means a short title, no `Fixes` line, and skipped Jira comment/transition.
- Keep local graph/wiki output out of git (`graphify-out/`, `docs/superpowers`).

## Test plan
- [x] `npm test` (65 passing), including overlay contract and `create-pr` Jira-optional lock
- [ ] Run `/review-pr-multiharness-ponytail` on a PR and confirm the report has a Ponytail section (`Lean already. Ship.` or tagged one-liners + `net: -<N>`) without dropping correctness
- [ ] Confirm GitHub pre-fills this template on a new PR and that empty Summary / Test plan would fail the contributing rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pull request review workflow with specialist checks and an over-engineering cleanup pass.
  - PR creation can now proceed without a Jira ticket.
  - Added a contributor guide covering setup, testing, reviews, and merge practices.
  - Added a standardized pull request template with summary and test plan sections.

- **Documentation**
  - Updated the README with new workflows and contribution guidance.
  - Added platform-native solution guidance and review criteria.

- **Tests**
  - Added checks validating the new templates, workflows, prompts, and documentation structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->